### PR TITLE
Fix overlapping issue for "Edit team" and "Delete team" modals

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -178,21 +178,21 @@ const TeamDetailsWrapper = (props: ITeamDetailsPageProps): JSX.Element => {
             })}
           </TabList>
         </Tabs>
-        {showDeleteTeamModal ? (
-          <DeleteTeamModal
-            onCancel={toggleDeleteTeamModal}
-            onSubmit={onDeleteSubmit}
-            name={team.name}
-          />
-        ) : null}
-        {showEditTeamModal ? (
-          <EditTeamModal
-            onCancel={toggleEditTeamModal}
-            onSubmit={onEditSubmit}
-            defaultName={team.name}
-          />
-        ) : null}
       </div>
+      {showDeleteTeamModal ? (
+        <DeleteTeamModal
+          onCancel={toggleDeleteTeamModal}
+          onSubmit={onDeleteSubmit}
+          name={team.name}
+        />
+      ) : null}
+      {showEditTeamModal ? (
+        <EditTeamModal
+          onCancel={toggleEditTeamModal}
+          onSubmit={onEditSubmit}
+          defaultName={team.name}
+        />
+      ) : null}
       {children}
     </div>
   );


### PR DESCRIPTION
Before the change:
![Screen Shot 2021-04-30 at 11 07 37 AM](https://user-images.githubusercontent.com/47070608/116715132-676f2500-a9a4-11eb-8663-fd5712fd69ca.png)

After the change:
![Screen Shot 2021-04-30 at 11 09 34 AM](https://user-images.githubusercontent.com/47070608/116715272-8ec5f200-a9a4-11eb-92f3-7991e25576f1.png)